### PR TITLE
Add CUDA PPISP Regularization Loss 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ from ppisp import PPISP, PPISPConfig
 
 # 1. Initialize
 ppisp = PPISP(num_cameras=3, num_frames=500)
+# Optional faster regularization loss:
+# ppisp = PPISP(num_cameras=3, num_frames=500, use_cuda_regularization_loss=True)
 
 # 2. Create optimizers and scheduler
 ppisp_optimizers = ppisp.create_optimizers()
@@ -98,6 +100,8 @@ rgb_out = ppisp(rgb_raw, pixel_coords, resolution=(W, H), camera_idx=camera_idx,
 ```
 
 Use `PPISPConfig` to customize regularization weights, learning rates, and controller activation timing.
+Set `use_cuda_regularization_loss=True` in `PPISPConfig` or the `PPISP` constructor to opt into
+the fused CUDA regularization loss. The default remains the original PyTorch loss path.
 
 ### Controller Distillation Mode
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ from ppisp import PPISP, PPISPConfig
 
 # 1. Initialize
 ppisp = PPISP(num_cameras=3, num_frames=500)
-# Optional faster regularization loss:
-# ppisp = PPISP(num_cameras=3, num_frames=500, use_cuda_regularization_loss=True)
 
 # 2. Create optimizers and scheduler
 ppisp_optimizers = ppisp.create_optimizers()
@@ -100,8 +98,7 @@ rgb_out = ppisp(rgb_raw, pixel_coords, resolution=(W, H), camera_idx=camera_idx,
 ```
 
 Use `PPISPConfig` to customize regularization weights, learning rates, and controller activation timing.
-Set `use_cuda_regularization_loss=True` in `PPISPConfig` or the `PPISP` constructor to opt into
-the fused CUDA regularization loss. The default remains the original PyTorch loss path.
+PPISP regularization loss uses the fused CUDA implementation.
 
 ### Controller Distillation Mode
 

--- a/ppisp/__init__.py
+++ b/ppisp/__init__.py
@@ -30,7 +30,6 @@ from dataclasses import dataclass
 
 import torch
 from torch import nn
-import torch.nn.functional as F
 
 import ppisp_cuda as _C
 
@@ -118,11 +117,6 @@ class PPISPConfig:
     """
 
     # Regularization weights
-    use_cuda_regularization_loss: bool = False
-    """Use the fused CUDA implementation for PPISP regularization loss.
-    Defaults to False to preserve the original PyTorch loss path.
-    """
-
     exposure_mean: float = 1.0
     """Encourage exposure mean ~ 0 to resolve SH <-> exposure ambiguity."""
 
@@ -529,8 +523,6 @@ class PPISP(nn.Module):
         num_cameras: Number of cameras in the scene
         num_frames: Total number of frames across all cameras
         config: PPISP configuration (regularization, optimizer, scheduler settings)
-        use_cuda_regularization_loss: Use the fused CUDA regularization loss.
-            Defaults to False.
     """
 
     def __init__(
@@ -538,14 +530,10 @@ class PPISP(nn.Module):
         num_cameras: int,
         num_frames: int,
         config: PPISPConfig = DEFAULT_PPISP_CONFIG,
-        use_cuda_regularization_loss: bool = False,
     ):
         super().__init__()
 
         self.config = config
-        self.use_cuda_regularization_loss = (
-            config.use_cuda_regularization_loss or use_cuda_regularization_loss
-        )
 
         # Warn if controller is enabled but will never train (ratio >= 1.0)
         if config.use_controller and config.controller_activation_ratio >= 1.0:
@@ -631,7 +619,6 @@ class PPISP(nn.Module):
         cls,
         state_dict: dict,
         config: PPISPConfig = DEFAULT_PPISP_CONFIG,
-        use_cuda_regularization_loss: bool = False,
     ) -> "PPISP":
         """Create PPISP instance from a state dict.
 
@@ -641,8 +628,6 @@ class PPISP(nn.Module):
         Args:
             state_dict: State dict from a saved PPISP module (via state_dict())
             config: PPISP configuration (default: DEFAULT_PPISP_CONFIG)
-            use_cuda_regularization_loss: Use the fused CUDA regularization loss.
-                Defaults to False.
 
         Returns:
             New PPISP instance with loaded state
@@ -657,7 +642,6 @@ class PPISP(nn.Module):
             num_cameras=num_cameras,
             num_frames=num_frames,
             config=config,
-            use_cuda_regularization_loss=use_cuda_regularization_loss,
         )
         instance.load_state_dict(state_dict)
 
@@ -805,51 +789,6 @@ class PPISP(nn.Module):
             Single scalar tensor with the total weighted regularization loss.
         """
         cfg = self.config
-        if not self.use_cuda_regularization_loss:
-            total_loss = torch.tensor(0.0, device=self.exposure_params.device)
-
-            # Exposure mean regularization (fix SH <-> exposure ambiguity)
-            if cfg.exposure_mean > 0:
-                exposure_residual = self.exposure_params.mean()
-                total_loss = total_loss + cfg.exposure_mean * F.smooth_l1_loss(
-                    exposure_residual, torch.zeros_like(exposure_residual), beta=0.1
-                )
-
-            # Vignetting center loss: optical center should be near image center (0, 0)
-            if cfg.vig_center > 0:
-                # [num_cameras, 3, 2]
-                vig_optical_center = self.vignetting_params[:, :, :2]
-                # [num_cameras, 3]
-                vig_center = (vig_optical_center ** 2).sum(dim=-1)
-                total_loss = total_loss + cfg.vig_center * vig_center.mean()
-
-            # Vignetting non-positivity loss: alpha coefficients should be <= 0
-            if cfg.vig_non_pos > 0:
-                # [num_cameras, 3, NUM_VIGNETTING_ALPHA_TERMS]
-                vig_alphas = self.vignetting_params[:, :, 2:]
-                vig_non_pos = F.relu(vig_alphas)  # penalty for positive values
-                total_loss = total_loss + cfg.vig_non_pos * vig_non_pos.mean()
-
-            # Vignetting channel variance
-            if cfg.vig_channel > 0:
-                total_loss = total_loss + cfg.vig_channel * \
-                    self.vignetting_params.var(dim=1, unbiased=False).mean()
-
-            # Color mean regularization using ZCA block-diagonal matrix
-            if cfg.color_mean > 0:
-                color_offsets = self.color_params @ self.color_pinv_block_diag
-                color_residual = color_offsets.mean(dim=0)
-                total_loss = total_loss + cfg.color_mean * F.smooth_l1_loss(
-                    color_residual, torch.zeros_like(color_residual), beta=0.005, reduction="mean"
-                )
-
-            # CRF channel variance
-            if cfg.crf_channel > 0:
-                total_loss = total_loss + cfg.crf_channel * \
-                    self.crf_params.var(dim=1, unbiased=False).mean()
-
-            return total_loss
-
         return _PPISPRegularizationFunction.apply(
             self.exposure_params,
             self.vignetting_params,

--- a/ppisp/__init__.py
+++ b/ppisp/__init__.py
@@ -29,8 +29,8 @@ parameters from rendered radiance images.
 from dataclasses import dataclass
 
 import torch
-import torch.nn.functional as F
 from torch import nn
+import torch.nn.functional as F
 
 import ppisp_cuda as _C
 
@@ -118,6 +118,11 @@ class PPISPConfig:
     """
 
     # Regularization weights
+    use_cuda_regularization_loss: bool = False
+    """Use the fused CUDA implementation for PPISP regularization loss.
+    Defaults to False to preserve the original PyTorch loss path.
+    """
+
     exposure_mean: float = 1.0
     """Encourage exposure mean ~ 0 to resolve SH <-> exposure ambiguity."""
 
@@ -260,6 +265,72 @@ class _PPISPFunction(torch.autograd.Function):
             None,  # camera_idx
             None,  # frame_idx
         )
+
+
+class _PPISPRegularizationFunction(torch.autograd.Function):
+    """Custom autograd function for the PPISP regularization loss."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        exposure_params: torch.Tensor,
+        vignetting_params: torch.Tensor,
+        color_params: torch.Tensor,
+        crf_params: torch.Tensor,
+        exposure_mean_weight: float,
+        vig_center_weight: float,
+        vig_channel_weight: float,
+        vig_non_pos_weight: float,
+        color_mean_weight: float,
+        crf_channel_weight: float,
+    ) -> torch.Tensor:
+        exposure_params = exposure_params.float().contiguous()
+        vignetting_params = vignetting_params.float().contiguous()
+        color_params = color_params.float().contiguous()
+        crf_params = crf_params.float().contiguous()
+
+        weights = (
+            float(exposure_mean_weight),
+            float(vig_center_weight),
+            float(vig_channel_weight),
+            float(vig_non_pos_weight),
+            float(color_mean_weight),
+            float(crf_channel_weight),
+        )
+
+        with torch.cuda.device(exposure_params.device):
+            loss, frame_mean_sums = _C.ppisp_regularization_forward(
+                exposure_params,
+                vignetting_params,
+                color_params,
+                crf_params,
+                *weights,
+            )
+
+        ctx.save_for_backward(
+            exposure_params, vignetting_params, color_params, crf_params, frame_mean_sums
+        )
+        ctx.weights = weights
+        return loss
+
+    @staticmethod
+    def backward(ctx, v_loss: torch.Tensor):
+        exposure_params, vignetting_params, color_params, crf_params, frame_mean_sums = (
+            ctx.saved_tensors
+        )
+
+        with torch.cuda.device(exposure_params.device):
+            grads = _C.ppisp_regularization_backward(
+                exposure_params,
+                vignetting_params,
+                color_params,
+                crf_params,
+                v_loss.contiguous(),
+                frame_mean_sums,
+                *ctx.weights,
+            )
+
+        return grads + (None,) * 6
 
 
 # =============================================================================
@@ -458,6 +529,8 @@ class PPISP(nn.Module):
         num_cameras: Number of cameras in the scene
         num_frames: Total number of frames across all cameras
         config: PPISP configuration (regularization, optimizer, scheduler settings)
+        use_cuda_regularization_loss: Use the fused CUDA regularization loss.
+            Defaults to False.
     """
 
     def __init__(
@@ -465,10 +538,14 @@ class PPISP(nn.Module):
         num_cameras: int,
         num_frames: int,
         config: PPISPConfig = DEFAULT_PPISP_CONFIG,
+        use_cuda_regularization_loss: bool = False,
     ):
         super().__init__()
 
         self.config = config
+        self.use_cuda_regularization_loss = (
+            config.use_cuda_regularization_loss or use_cuda_regularization_loss
+        )
 
         # Warn if controller is enabled but will never train (ratio >= 1.0)
         if config.use_controller and config.controller_activation_ratio >= 1.0:
@@ -554,6 +631,7 @@ class PPISP(nn.Module):
         cls,
         state_dict: dict,
         config: PPISPConfig = DEFAULT_PPISP_CONFIG,
+        use_cuda_regularization_loss: bool = False,
     ) -> "PPISP":
         """Create PPISP instance from a state dict.
 
@@ -563,6 +641,8 @@ class PPISP(nn.Module):
         Args:
             state_dict: State dict from a saved PPISP module (via state_dict())
             config: PPISP configuration (default: DEFAULT_PPISP_CONFIG)
+            use_cuda_regularization_loss: Use the fused CUDA regularization loss.
+                Defaults to False.
 
         Returns:
             New PPISP instance with loaded state
@@ -573,8 +653,12 @@ class PPISP(nn.Module):
         num_frames = state_dict["exposure_params"].shape[0]
 
         # Create instance with inferred dimensions
-        instance = cls(num_cameras=num_cameras,
-                       num_frames=num_frames, config=config)
+        instance = cls(
+            num_cameras=num_cameras,
+            num_frames=num_frames,
+            config=config,
+            use_cuda_regularization_loss=use_cuda_regularization_loss,
+        )
         instance.load_state_dict(state_dict)
 
         return instance
@@ -721,49 +805,63 @@ class PPISP(nn.Module):
             Single scalar tensor with the total weighted regularization loss.
         """
         cfg = self.config
-        total_loss = torch.tensor(0.0, device=self.exposure_params.device)
+        if not self.use_cuda_regularization_loss:
+            total_loss = torch.tensor(0.0, device=self.exposure_params.device)
 
-        # Exposure mean regularization (fix SH <-> exposure ambiguity)
-        if cfg.exposure_mean > 0:
-            exposure_residual = self.exposure_params.mean()
-            total_loss = total_loss + cfg.exposure_mean * F.smooth_l1_loss(
-                exposure_residual, torch.zeros_like(exposure_residual), beta=0.1
-            )
+            # Exposure mean regularization (fix SH <-> exposure ambiguity)
+            if cfg.exposure_mean > 0:
+                exposure_residual = self.exposure_params.mean()
+                total_loss = total_loss + cfg.exposure_mean * F.smooth_l1_loss(
+                    exposure_residual, torch.zeros_like(exposure_residual), beta=0.1
+                )
 
-        # Vignetting center loss: optical center should be near image center (0, 0)
-        if cfg.vig_center > 0:
-            # [num_cameras, 3, 2]
-            vig_optical_center = self.vignetting_params[:, :, :2]
-            # [num_cameras, 3]
-            vig_center = (vig_optical_center ** 2).sum(dim=-1)
-            total_loss = total_loss + cfg.vig_center * vig_center.mean()
+            # Vignetting center loss: optical center should be near image center (0, 0)
+            if cfg.vig_center > 0:
+                # [num_cameras, 3, 2]
+                vig_optical_center = self.vignetting_params[:, :, :2]
+                # [num_cameras, 3]
+                vig_center = (vig_optical_center ** 2).sum(dim=-1)
+                total_loss = total_loss + cfg.vig_center * vig_center.mean()
 
-        # Vignetting non-positivity loss: alpha coefficients should be <= 0
-        if cfg.vig_non_pos > 0:
-            # [num_cameras, 3, NUM_VIGNETTING_ALPHA_TERMS]
-            vig_alphas = self.vignetting_params[:, :, 2:]
-            vig_non_pos = F.relu(vig_alphas)  # penalty for positive values
-            total_loss = total_loss + cfg.vig_non_pos * vig_non_pos.mean()
+            # Vignetting non-positivity loss: alpha coefficients should be <= 0
+            if cfg.vig_non_pos > 0:
+                # [num_cameras, 3, NUM_VIGNETTING_ALPHA_TERMS]
+                vig_alphas = self.vignetting_params[:, :, 2:]
+                vig_non_pos = F.relu(vig_alphas)  # penalty for positive values
+                total_loss = total_loss + cfg.vig_non_pos * vig_non_pos.mean()
 
-        # Vignetting channel variance
-        if cfg.vig_channel > 0:
-            total_loss = total_loss + cfg.vig_channel * \
-                self.vignetting_params.var(dim=1, unbiased=False).mean()
+            # Vignetting channel variance
+            if cfg.vig_channel > 0:
+                total_loss = total_loss + cfg.vig_channel * \
+                    self.vignetting_params.var(dim=1, unbiased=False).mean()
 
-        # Color mean regularization using ZCA block-diagonal matrix
-        if cfg.color_mean > 0:
-            color_offsets = self.color_params @ self.color_pinv_block_diag
-            color_residual = color_offsets.mean(dim=0)
-            total_loss = total_loss + cfg.color_mean * F.smooth_l1_loss(
-                color_residual, torch.zeros_like(color_residual), beta=0.005, reduction="mean"
-            )
+            # Color mean regularization using ZCA block-diagonal matrix
+            if cfg.color_mean > 0:
+                color_offsets = self.color_params @ self.color_pinv_block_diag
+                color_residual = color_offsets.mean(dim=0)
+                total_loss = total_loss + cfg.color_mean * F.smooth_l1_loss(
+                    color_residual, torch.zeros_like(color_residual), beta=0.005, reduction="mean"
+                )
 
-        # CRF channel variance
-        if cfg.crf_channel > 0:
-            total_loss = total_loss + cfg.crf_channel * \
-                self.crf_params.var(dim=1, unbiased=False).mean()
+            # CRF channel variance
+            if cfg.crf_channel > 0:
+                total_loss = total_loss + cfg.crf_channel * \
+                    self.crf_params.var(dim=1, unbiased=False).mean()
 
-        return total_loss
+            return total_loss
+
+        return _PPISPRegularizationFunction.apply(
+            self.exposure_params,
+            self.vignetting_params,
+            self.color_params,
+            self.crf_params,
+            cfg.exposure_mean,
+            cfg.vig_center,
+            cfg.vig_channel,
+            cfg.vig_non_pos,
+            cfg.color_mean,
+            cfg.crf_channel,
+        )
 
     def create_optimizers(self) -> list[torch.optim.Optimizer]:
         """Create optimizers for PPISP parameters.

--- a/ppisp/bindings.h
+++ b/ppisp/bindings.h
@@ -20,6 +20,8 @@
 
 #include <torch/extension.h>
 
+#include "src/ppisp_constants.h"
+
 // =============================================================================
 // Forward pass for PPISP image processing
 // =============================================================================
@@ -56,6 +58,48 @@ void ppisp_backward(
     // Dimensions
     int num_pixels, int num_cameras, int num_frames, int resolution_w, int resolution_h,
     int camera_idx, int frame_idx);
+
+// =============================================================================
+// Forward/backward for PPISP regularization loss
+// =============================================================================
+
+void ppisp_regularization_forward(
+    // Parameters (per-frame/per-camera)
+    const float *exposure_params,    // [num_frames]
+    const float *vignetting_params,  // [num_cameras, 3, 5]
+    const float *color_params,       // [num_frames, 8]
+    const float *crf_params,         // [num_cameras, 3, 4]
+    // Outputs
+    float *loss_out,         // scalar
+    float *frame_mean_sums,  // [PPISP_FRAME_MEAN_SUMS_SIZE]
+    // Dimensions
+    int num_cameras, int num_frames,
+    // Weights
+    float exposure_mean_weight, float vig_center_weight,
+    float vig_channel_weight, float vig_non_pos_weight, float color_mean_weight,
+    float crf_channel_weight);
+
+void ppisp_regularization_backward(
+    // Parameters (per-frame/per-camera)
+    const float *exposure_params,    // [num_frames]
+    const float *vignetting_params,  // [num_cameras, 3, 5]
+    const float *color_params,       // [num_frames, 8]
+    const float *crf_params,         // [num_cameras, 3, 4]
+    // Upstream gradient
+    const float *grad_loss,  // scalar
+    // Gradients w.r.t. parameters
+    float *grad_exposure_params,    // [num_frames]
+    float *grad_vignetting_params,  // [num_cameras, 3, 5]
+    float *grad_color_params,       // [num_frames, 8]
+    float *grad_crf_params,         // [num_cameras, 3, 4]
+    // Saved forward output
+    float *frame_mean_sums,  // [PPISP_FRAME_MEAN_SUMS_SIZE]
+    // Dimensions
+    int num_cameras, int num_frames,
+    // Weights
+    float exposure_mean_weight,
+    float vig_center_weight, float vig_channel_weight, float vig_non_pos_weight,
+    float color_mean_weight, float crf_channel_weight);
 
 // =============================================================================
 // PyTorch tensor wrappers
@@ -111,6 +155,62 @@ ppisp_backward_tensor(torch::Tensor exposure_params, torch::Tensor vignetting_pa
 
     return std::make_tuple(v_exposure_params, v_vignetting_params, v_color_params, v_crf_params,
                            v_rgb_in);
+}
+
+std::tuple<torch::Tensor, torch::Tensor> ppisp_regularization_forward_tensor(
+    torch::Tensor exposure_params,    // [num_frames]
+    torch::Tensor vignetting_params,  // [num_cameras, 3, 5]
+    torch::Tensor color_params,       // [num_frames, 8]
+    torch::Tensor crf_params,         // [num_cameras, 3, 4]
+    float exposure_mean_weight, float vig_center_weight,
+    float vig_channel_weight, float vig_non_pos_weight, float color_mean_weight,
+    float crf_channel_weight) {
+    int num_cameras = crf_params.size(0);
+    int num_frames = exposure_params.size(0);
+
+    auto loss = torch::zeros({}, exposure_params.options());
+    auto frame_mean_sums = torch::zeros({PPISP_FRAME_MEAN_SUMS_SIZE}, exposure_params.options());
+
+    ppisp_regularization_forward(
+        exposure_params.data_ptr<float>(), vignetting_params.data_ptr<float>(),
+        color_params.data_ptr<float>(), crf_params.data_ptr<float>(), loss.data_ptr<float>(),
+        frame_mean_sums.data_ptr<float>(), num_cameras, num_frames, exposure_mean_weight,
+        vig_center_weight, vig_channel_weight, vig_non_pos_weight, color_mean_weight,
+        crf_channel_weight);
+
+    return std::make_tuple(loss, frame_mean_sums);
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+ppisp_regularization_backward_tensor(
+    torch::Tensor exposure_params,    // [num_frames]
+    torch::Tensor vignetting_params,  // [num_cameras, 3, 5]
+    torch::Tensor color_params,       // [num_frames, 8]
+    torch::Tensor crf_params,         // [num_cameras, 3, 4]
+    torch::Tensor grad_loss,          // scalar
+    torch::Tensor frame_mean_sums,    // [PPISP_FRAME_MEAN_SUMS_SIZE]
+    float exposure_mean_weight, float vig_center_weight, float vig_channel_weight,
+    float vig_non_pos_weight, float color_mean_weight, float crf_channel_weight) {
+    int num_cameras = crf_params.size(0);
+    int num_frames = exposure_params.size(0);
+
+    auto grad_loss_contig = grad_loss.contiguous();
+    auto grad_exposure_params = torch::zeros_like(exposure_params);
+    auto grad_vignetting_params = torch::zeros_like(vignetting_params);
+    auto grad_color_params = torch::zeros_like(color_params);
+    auto grad_crf_params = torch::zeros_like(crf_params);
+
+    ppisp_regularization_backward(
+        exposure_params.data_ptr<float>(), vignetting_params.data_ptr<float>(),
+        color_params.data_ptr<float>(), crf_params.data_ptr<float>(), grad_loss_contig.data_ptr<float>(),
+        grad_exposure_params.data_ptr<float>(), grad_vignetting_params.data_ptr<float>(),
+        grad_color_params.data_ptr<float>(), grad_crf_params.data_ptr<float>(),
+        frame_mean_sums.data_ptr<float>(), num_cameras, num_frames, exposure_mean_weight,
+        vig_center_weight, vig_channel_weight, vig_non_pos_weight, color_mean_weight,
+        crf_channel_weight);
+
+    return std::make_tuple(grad_exposure_params, grad_vignetting_params, grad_color_params,
+                           grad_crf_params);
 }
 
 #endif  // _PPISP_BINDINGS_H_INC

--- a/ppisp/src/ppisp_constants.h
+++ b/ppisp/src/ppisp_constants.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 
-#include "bindings.h"
+#pragma once
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("ppisp_forward", &ppisp_forward_tensor);
-    m.def("ppisp_backward", &ppisp_backward_tensor);
-    m.def("ppisp_regularization_forward", &ppisp_regularization_forward_tensor);
-    m.def("ppisp_regularization_backward", &ppisp_regularization_backward_tensor);
-}
+constexpr int PPISP_BLOCK_SIZE = 256;
+constexpr int PPISP_COLOR_PARAMS = 8;
+constexpr int PPISP_FRAME_MEAN_SUMS_SIZE = 1 + PPISP_COLOR_PARAMS;
+constexpr int PPISP_CRF_PARAMS_PER_CHANNEL = 4;
+constexpr int PPISP_VIGNETTING_PARAMS_PER_CHANNEL = 5;

--- a/ppisp/src/ppisp_impl.cu
+++ b/ppisp/src/ppisp_impl.cu
@@ -18,8 +18,11 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
+#include <algorithm>
+
 #include <cub/cub.cuh>
 
+#include "ppisp_constants.h"
 #include "ppisp_math.cuh"
 #include "ppisp_math_bwd.cuh"
 
@@ -27,11 +30,36 @@
 // Configuration
 // ============================================================================
 
-// CUDA kernel launch configuration
-constexpr int PPISP_BLOCK_SIZE = 256;
-
 // Helper function to compute grid size
 inline int divUp(int a, int b) { return (a + b - 1) / b; }
+
+__device__ __forceinline__ float ppisp_smooth_l1(float x, float beta) {
+    float ax = fabsf(x);
+    return ax < beta ? 0.5f * x * x / beta : ax - 0.5f * beta;
+}
+
+__device__ __forceinline__ float ppisp_smooth_l1_bwd(float x, float beta) {
+    float ax = fabsf(x);
+    if (ax < beta) {
+        return x / beta;
+    }
+    return x < 0.0f ? -1.0f : 1.0f;
+}
+
+__device__ __forceinline__ float2 ppisp_apply_color_block(int block_idx,
+                                                          const float2 &latent) {
+    const float *m = COLOR_PINV_BLOCKS[block_idx];
+    return make_float2(__fmaf_rn(m[0], latent.x, m[1] * latent.y),
+                       __fmaf_rn(m[2], latent.x, m[3] * latent.y));
+}
+
+__device__ __forceinline__ void ppisp_color_offset_grad_to_latent(int block_idx,
+                                                                  const float2 &grad_offset,
+                                                                  float2 &grad_latent) {
+    const float *m = COLOR_PINV_BLOCKS[block_idx];
+    grad_latent.x = __fmaf_rn(m[0], grad_offset.x, m[2] * grad_offset.y);
+    grad_latent.y = __fmaf_rn(m[1], grad_offset.x, m[3] * grad_offset.y);
+}
 
 // ============================================================================
 // PPISP Forward Kernel
@@ -361,5 +389,450 @@ void ppisp_backward(const float *exposure_params, const float *vignetting_params
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess) {
         printf("CUDA Error in ppisp_backward: %s\n", cudaGetErrorString(err));
+    }
+}
+
+// ============================================================================
+// PPISP Regularization Loss Kernels
+// ============================================================================
+
+// Frame-mean loss group: exposure_mean and color_mean. These terms need
+// cross-frame sums before the final mean loss can be computed.
+// frame_mean_sums shape: [PPISP_FRAME_MEAN_SUMS_SIZE].
+// frame_mean_sums[0] stores sum(exposure_params); frame_mean_sums[1 + i]
+// stores the summed color offset component for i in [0, PPISP_COLOR_PARAMS).
+template <int BLOCK_SIZE>
+__global__ void ppisp_regularization_frame_mean_sums_kernel(
+    const float *__restrict__ exposure_params,
+    const ColorPPISPParams *__restrict__ color_params, float *__restrict__ frame_mean_sums,
+    int num_frames, bool compute_exposure_stats, bool compute_color_stats) {
+    int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride = blockDim.x * gridDim.x;
+    float exposure_sum = 0.0f;
+    float color_sums[PPISP_COLOR_PARAMS];
+
+#pragma unroll
+    for (int i = 0; i < PPISP_COLOR_PARAMS; i++) {
+        color_sums[i] = 0.0f;
+    }
+
+    for (int frame = tid; frame < num_frames; frame += stride) {
+        if (compute_exposure_stats) {
+            exposure_sum += exposure_params[frame];
+        }
+
+        if (compute_color_stats) {
+            const ColorPPISPParams &params = color_params[frame];
+            float2 offsets[4] = {
+                ppisp_apply_color_block(0, params.b),
+                ppisp_apply_color_block(1, params.r),
+                ppisp_apply_color_block(2, params.g),
+                ppisp_apply_color_block(3, params.n),
+            };
+
+#pragma unroll
+            for (int block = 0; block < 4; block++) {
+                color_sums[block * 2] += offsets[block].x;
+                color_sums[block * 2 + 1] += offsets[block].y;
+            }
+        }
+    }
+
+    typedef cub::BlockReduce<float, BLOCK_SIZE> BlockReduceFloat;
+    __shared__ typename BlockReduceFloat::TempStorage temp;
+
+    if (compute_exposure_stats) {
+        float block_exposure_sum = BlockReduceFloat(temp).Sum(exposure_sum);
+        if (threadIdx.x == 0) {
+            atomicAdd(&frame_mean_sums[0], block_exposure_sum);
+        }
+    }
+
+    __syncthreads();
+
+    if (compute_color_stats) {
+#pragma unroll
+        for (int i = 0; i < PPISP_COLOR_PARAMS; i++) {
+            float block_color_sum = BlockReduceFloat(temp).Sum(color_sums[i]);
+            if (threadIdx.x == 0) {
+                atomicAdd(&frame_mean_sums[1 + i], block_color_sum);
+            }
+            __syncthreads();
+        }
+    }
+}
+
+__global__ void ppisp_regularization_frame_mean_loss_kernel(float *__restrict__ loss,
+                                                            const float *__restrict__ frame_mean_sums,
+                                                            int num_frames,
+                                                            float exposure_mean_weight,
+                                                            float color_mean_weight) {
+    if (threadIdx.x != 0 || blockIdx.x != 0 || num_frames <= 0) {
+        return;
+    }
+
+    float inv_frames = 1.0f / static_cast<float>(num_frames);
+
+    // Exposure mean regularization (fix SH <-> exposure ambiguity)
+    if (exposure_mean_weight > 0.0f) {
+        float exposure_residual = frame_mean_sums[0] * inv_frames;
+        atomicAdd(loss, exposure_mean_weight * ppisp_smooth_l1(exposure_residual, 0.1f));
+    }
+
+    // Color mean regularization using ZCA block-diagonal matrix
+    if (color_mean_weight > 0.0f) {
+        float color_loss = 0.0f;
+#pragma unroll
+        for (int i = 0; i < PPISP_COLOR_PARAMS; i++) {
+            float color_residual = frame_mean_sums[1 + i] * inv_frames;
+            color_loss += ppisp_smooth_l1(color_residual, 0.005f);
+        }
+        atomicAdd(loss, color_mean_weight * color_loss / static_cast<float>(PPISP_COLOR_PARAMS));
+    }
+}
+
+// Camera-parameter loss group: vig_center, vig_non_pos, vig_channel, and
+// crf_channel. These terms reduce directly over per-camera parameter tensors.
+template <int BLOCK_SIZE>
+__global__ void ppisp_regularization_camera_param_loss_kernel(
+    const float *__restrict__ vignetting_params, const float *__restrict__ crf_params,
+    float *__restrict__ loss, int num_cameras, float vig_center_weight,
+    float vig_channel_weight, float vig_non_pos_weight, float crf_channel_weight) {
+    int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride = blockDim.x * gridDim.x;
+    int total_vig = num_cameras * 3 * PPISP_VIGNETTING_PARAMS_PER_CHANNEL;
+    int total_vig_channel = num_cameras * PPISP_VIGNETTING_PARAMS_PER_CHANNEL;
+    int total_crf_channel = num_cameras * PPISP_CRF_PARAMS_PER_CHANNEL;
+    int total = total_vig > total_vig_channel ? total_vig : total_vig_channel;
+    total = total > total_crf_channel ? total : total_crf_channel;
+
+    float inv_vig_center_denom = 1.0f / static_cast<float>(num_cameras * 3);
+    float inv_vig_non_pos_denom = 1.0f / static_cast<float>(num_cameras * 3 * 3);
+    float inv_vig_channel_denom =
+        1.0f / static_cast<float>(num_cameras * PPISP_VIGNETTING_PARAMS_PER_CHANNEL * 3);
+    float inv_crf_channel_denom =
+        1.0f / static_cast<float>(num_cameras * PPISP_CRF_PARAMS_PER_CHANNEL * 3);
+
+    float vig_center_part = 0.0f;
+    float vig_non_pos_part = 0.0f;
+    float vig_channel_part = 0.0f;
+    float crf_channel_part = 0.0f;
+
+    for (int idx = tid; idx < total; idx += stride) {
+        if (idx < total_vig) {
+            int param_idx = idx % PPISP_VIGNETTING_PARAMS_PER_CHANNEL;
+            float val = vignetting_params[idx];
+
+            // Vignetting center loss: optical center should be near image center (0, 0)
+            if (vig_center_weight > 0.0f && param_idx < 2) {
+                vig_center_part += vig_center_weight * val * val * inv_vig_center_denom;
+            }
+
+            // Vignetting non-positivity loss: alpha coefficients should be <= 0
+            if (vig_non_pos_weight > 0.0f && param_idx >= 2 && val > 0.0f) {
+                vig_non_pos_part += vig_non_pos_weight * val * inv_vig_non_pos_denom;
+            }
+        }
+
+        // Vignetting channel variance
+        if (idx < total_vig_channel && vig_channel_weight > 0.0f) {
+            int param_idx = idx % PPISP_VIGNETTING_PARAMS_PER_CHANNEL;
+            int camera_idx = idx / PPISP_VIGNETTING_PARAMS_PER_CHANNEL;
+            int base = camera_idx * 3 * PPISP_VIGNETTING_PARAMS_PER_CHANNEL + param_idx;
+            float v0 = vignetting_params[base];
+            float v1 = vignetting_params[base + PPISP_VIGNETTING_PARAMS_PER_CHANNEL];
+            float v2 = vignetting_params[base + 2 * PPISP_VIGNETTING_PARAMS_PER_CHANNEL];
+            float mean = (v0 + v1 + v2) / 3.0f;
+            float d0 = v0 - mean;
+            float d1 = v1 - mean;
+            float d2 = v2 - mean;
+            vig_channel_part +=
+                vig_channel_weight * (d0 * d0 + d1 * d1 + d2 * d2) * inv_vig_channel_denom;
+        }
+
+        // CRF channel variance
+        if (idx < total_crf_channel && crf_channel_weight > 0.0f) {
+            int param_idx = idx % PPISP_CRF_PARAMS_PER_CHANNEL;
+            int camera_idx = idx / PPISP_CRF_PARAMS_PER_CHANNEL;
+            int base = camera_idx * 3 * PPISP_CRF_PARAMS_PER_CHANNEL + param_idx;
+            float v0 = crf_params[base];
+            float v1 = crf_params[base + PPISP_CRF_PARAMS_PER_CHANNEL];
+            float v2 = crf_params[base + 2 * PPISP_CRF_PARAMS_PER_CHANNEL];
+            float mean = (v0 + v1 + v2) / 3.0f;
+            float d0 = v0 - mean;
+            float d1 = v1 - mean;
+            float d2 = v2 - mean;
+            crf_channel_part +=
+                crf_channel_weight * (d0 * d0 + d1 * d1 + d2 * d2) * inv_crf_channel_denom;
+        }
+    }
+
+    typedef cub::BlockReduce<float, BLOCK_SIZE> BlockReduceFloat;
+    __shared__ typename BlockReduceFloat::TempStorage temp;
+
+    if (vig_center_weight > 0.0f) {
+        float block_part = BlockReduceFloat(temp).Sum(vig_center_part);
+        if (threadIdx.x == 0) {
+            atomicAdd(loss, block_part);
+        }
+    }
+
+    __syncthreads();
+
+    if (vig_non_pos_weight > 0.0f) {
+        float block_part = BlockReduceFloat(temp).Sum(vig_non_pos_part);
+        if (threadIdx.x == 0) {
+            atomicAdd(loss, block_part);
+        }
+    }
+
+    __syncthreads();
+
+    if (vig_channel_weight > 0.0f) {
+        float block_part = BlockReduceFloat(temp).Sum(vig_channel_part);
+        if (threadIdx.x == 0) {
+            atomicAdd(loss, block_part);
+        }
+    }
+
+    __syncthreads();
+
+    if (crf_channel_weight > 0.0f) {
+        float block_part = BlockReduceFloat(temp).Sum(crf_channel_part);
+        if (threadIdx.x == 0) {
+            atomicAdd(loss, block_part);
+        }
+    }
+}
+
+__global__ void ppisp_regularization_frame_mean_backward_kernel(
+    const float *__restrict__ frame_mean_sums, const float *__restrict__ grad_loss,
+    float *__restrict__ grad_exposure_params, float *__restrict__ grad_color_params,
+    int num_frames, float exposure_mean_weight, float color_mean_weight) {
+    int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride = blockDim.x * gridDim.x;
+
+    if (num_frames <= 0) {
+        return;
+    }
+
+    float inv_frames = 1.0f / static_cast<float>(num_frames);
+    float upstream = grad_loss[0];
+    float grad_exposure = 0.0f;
+    float grad_offsets[PPISP_COLOR_PARAMS];
+
+    if (exposure_mean_weight > 0.0f) {
+        float exposure_residual = frame_mean_sums[0] * inv_frames;
+        grad_exposure = upstream * exposure_mean_weight *
+                        ppisp_smooth_l1_bwd(exposure_residual, 0.1f) * inv_frames;
+    }
+
+#pragma unroll
+    for (int i = 0; i < PPISP_COLOR_PARAMS; i++) {
+        grad_offsets[i] = 0.0f;
+        if (color_mean_weight > 0.0f) {
+            float color_residual = frame_mean_sums[1 + i] * inv_frames;
+            grad_offsets[i] =
+                upstream * color_mean_weight * ppisp_smooth_l1_bwd(color_residual, 0.005f) *
+                inv_frames / static_cast<float>(PPISP_COLOR_PARAMS);
+        }
+    }
+
+    for (int frame = tid; frame < num_frames; frame += stride) {
+        if (exposure_mean_weight > 0.0f) {
+            grad_exposure_params[frame] += grad_exposure;
+        }
+
+        if (color_mean_weight > 0.0f) {
+            int base = frame * PPISP_COLOR_PARAMS;
+#pragma unroll
+            for (int block = 0; block < 4; block++) {
+                float2 grad_offset =
+                    make_float2(grad_offsets[block * 2], grad_offsets[block * 2 + 1]);
+                float2 grad_latent;
+                ppisp_color_offset_grad_to_latent(block, grad_offset, grad_latent);
+                grad_color_params[base + block * 2] += grad_latent.x;
+                grad_color_params[base + block * 2 + 1] += grad_latent.y;
+            }
+        }
+    }
+}
+
+__global__ void ppisp_regularization_vignetting_backward_kernel(
+    const float *__restrict__ vignetting_params, const float *__restrict__ grad_loss,
+    float *__restrict__ grad_vignetting_params, int num_cameras, float vig_center_weight,
+    float vig_channel_weight, float vig_non_pos_weight) {
+    int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride = blockDim.x * gridDim.x;
+    int total_vig = num_cameras * PPISP_VIGNETTING_PARAMS_PER_CHANNEL;
+    float upstream = grad_loss[0];
+    float inv_vig_center_denom = 1.0f / static_cast<float>(num_cameras * 3);
+    float inv_vig_non_pos_denom = 1.0f / static_cast<float>(num_cameras * 3 * 3);
+    float inv_vig_channel_denom =
+        1.0f / static_cast<float>(num_cameras * PPISP_VIGNETTING_PARAMS_PER_CHANNEL);
+
+    for (int idx = tid; idx < total_vig; idx += stride) {
+        int param_idx = idx % PPISP_VIGNETTING_PARAMS_PER_CHANNEL;
+        int camera_idx = idx / PPISP_VIGNETTING_PARAMS_PER_CHANNEL;
+        int base = camera_idx * 3 * PPISP_VIGNETTING_PARAMS_PER_CHANNEL + param_idx;
+        float v0 = vignetting_params[base];
+        float v1 = vignetting_params[base + PPISP_VIGNETTING_PARAMS_PER_CHANNEL];
+        float v2 = vignetting_params[base + 2 * PPISP_VIGNETTING_PARAMS_PER_CHANNEL];
+        float mean = (v0 + v1 + v2) / 3.0f;
+        float values[3] = {v0, v1, v2};
+
+#pragma unroll
+        for (int channel = 0; channel < 3; channel++) {
+            float val = values[channel];
+            float grad = 0.0f;
+
+            if (vig_center_weight > 0.0f && param_idx < 2) {
+                grad += vig_center_weight * 2.0f * val * inv_vig_center_denom;
+            }
+
+            if (vig_non_pos_weight > 0.0f && param_idx >= 2 && val > 0.0f) {
+                grad += vig_non_pos_weight * inv_vig_non_pos_denom;
+            }
+
+            if (vig_channel_weight > 0.0f) {
+                grad += vig_channel_weight * (2.0f / 3.0f) * (val - mean) *
+                        inv_vig_channel_denom;
+            }
+
+            grad_vignetting_params[base + channel * PPISP_VIGNETTING_PARAMS_PER_CHANNEL] +=
+                upstream * grad;
+        }
+    }
+}
+
+__global__ void ppisp_regularization_crf_backward_kernel(
+    const float *__restrict__ crf_params, const float *__restrict__ grad_loss,
+    float *__restrict__ grad_crf_params, int num_cameras, float crf_channel_weight) {
+    int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride = blockDim.x * gridDim.x;
+    int total_crf = num_cameras * PPISP_CRF_PARAMS_PER_CHANNEL;
+    float upstream = grad_loss[0];
+    float inv_crf_channel_denom =
+        1.0f / static_cast<float>(num_cameras * PPISP_CRF_PARAMS_PER_CHANNEL);
+
+    for (int idx = tid; idx < total_crf; idx += stride) {
+        int param_idx = idx % PPISP_CRF_PARAMS_PER_CHANNEL;
+        int camera_idx = idx / PPISP_CRF_PARAMS_PER_CHANNEL;
+        int base = camera_idx * 3 * PPISP_CRF_PARAMS_PER_CHANNEL + param_idx;
+        float v0 = crf_params[base];
+        float v1 = crf_params[base + PPISP_CRF_PARAMS_PER_CHANNEL];
+        float v2 = crf_params[base + 2 * PPISP_CRF_PARAMS_PER_CHANNEL];
+        float mean = (v0 + v1 + v2) / 3.0f;
+        float values[3] = {v0, v1, v2};
+
+#pragma unroll
+        for (int channel = 0; channel < 3; channel++) {
+            float grad = crf_channel_weight * (2.0f / 3.0f) * (values[channel] - mean) *
+                         inv_crf_channel_denom;
+            grad_crf_params[base + channel * PPISP_CRF_PARAMS_PER_CHANNEL] += upstream * grad;
+        }
+    }
+}
+
+// ============================================================================
+// Regularization Loss Implementation
+// ============================================================================
+
+// Inputs:
+// - exposure_params: [num_frames]
+// - vignetting_params: [num_cameras, 3, PPISP_VIGNETTING_PARAMS_PER_CHANNEL]
+// - color_params: [num_frames, PPISP_COLOR_PARAMS]
+// - crf_params: [num_cameras, 3, PPISP_CRF_PARAMS_PER_CHANNEL]
+// Outputs, expected zero-initialized:
+// - loss_out: scalar total weighted regularization loss
+// - frame_mean_sums: [PPISP_FRAME_MEAN_SUMS_SIZE], saved for backward
+// frame_mean_sums layout:
+// [sum(exposure_params), sum(color_offset_0), ..., sum(color_offset_7)].
+void ppisp_regularization_forward(
+    const float *exposure_params, const float *vignetting_params, const float *color_params,
+    const float *crf_params, float *loss_out, float *frame_mean_sums, int num_cameras,
+    int num_frames, float exposure_mean_weight, float vig_center_weight,
+    float vig_channel_weight, float vig_non_pos_weight, float color_mean_weight,
+    float crf_channel_weight) {
+    const int threads = PPISP_BLOCK_SIZE;
+
+    if (num_frames > 0 && (exposure_mean_weight > 0.0f || color_mean_weight > 0.0f)) {
+        int blocks = divUp(num_frames, threads);
+        ppisp_regularization_frame_mean_sums_kernel<PPISP_BLOCK_SIZE><<<blocks, threads>>>(
+            exposure_params, reinterpret_cast<const ColorPPISPParams *>(color_params),
+            frame_mean_sums,
+            num_frames, exposure_mean_weight > 0.0f, color_mean_weight > 0.0f);
+        ppisp_regularization_frame_mean_loss_kernel<<<1, 1>>>(
+            loss_out, frame_mean_sums, num_frames, exposure_mean_weight, color_mean_weight);
+    }
+
+    if (num_cameras > 0 &&
+        (vig_center_weight > 0.0f || vig_channel_weight > 0.0f ||
+         vig_non_pos_weight > 0.0f || crf_channel_weight > 0.0f)) {
+        int total_vig = num_cameras * 3 * PPISP_VIGNETTING_PARAMS_PER_CHANNEL;
+        int total_vig_channel = num_cameras * PPISP_VIGNETTING_PARAMS_PER_CHANNEL;
+        int total_crf_channel = num_cameras * PPISP_CRF_PARAMS_PER_CHANNEL;
+        int blocks = divUp(std::max(total_vig, std::max(total_vig_channel, total_crf_channel)),
+                           threads);
+        ppisp_regularization_camera_param_loss_kernel<PPISP_BLOCK_SIZE><<<blocks, threads>>>(
+            vignetting_params, crf_params, loss_out, num_cameras, vig_center_weight,
+            vig_channel_weight, vig_non_pos_weight, crf_channel_weight);
+    }
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        printf("CUDA Error in ppisp_regularization_forward: %s\n", cudaGetErrorString(err));
+    }
+}
+
+// Inputs:
+// - exposure_params: [num_frames]
+// - vignetting_params: [num_cameras, 3, PPISP_VIGNETTING_PARAMS_PER_CHANNEL]
+// - color_params: [num_frames, PPISP_COLOR_PARAMS]
+// - crf_params: [num_cameras, 3, PPISP_CRF_PARAMS_PER_CHANNEL]
+// - grad_loss: scalar upstream gradient
+// - frame_mean_sums: [PPISP_FRAME_MEAN_SUMS_SIZE] output from forward
+// Outputs, expected zero-initialized:
+// - grad_exposure_params: [num_frames]
+// - grad_vignetting_params: [num_cameras, 3, PPISP_VIGNETTING_PARAMS_PER_CHANNEL]
+// - grad_color_params: [num_frames, PPISP_COLOR_PARAMS]
+// - grad_crf_params: [num_cameras, 3, PPISP_CRF_PARAMS_PER_CHANNEL]
+// frame_mean_sums layout:
+// [sum(exposure_params), sum(color_offset_0), ..., sum(color_offset_7)].
+void ppisp_regularization_backward(
+    const float *exposure_params, const float *vignetting_params, const float *color_params,
+    const float *crf_params, const float *grad_loss, float *grad_exposure_params,
+    float *grad_vignetting_params, float *grad_color_params, float *grad_crf_params,
+    float *frame_mean_sums, int num_cameras, int num_frames, float exposure_mean_weight,
+    float vig_center_weight, float vig_channel_weight, float vig_non_pos_weight,
+    float color_mean_weight, float crf_channel_weight) {
+    const int threads = PPISP_BLOCK_SIZE;
+
+    if (num_frames > 0 && (exposure_mean_weight > 0.0f || color_mean_weight > 0.0f)) {
+        int blocks = divUp(num_frames, threads);
+        ppisp_regularization_frame_mean_backward_kernel<<<blocks, threads>>>(
+            frame_mean_sums, grad_loss, grad_exposure_params, grad_color_params, num_frames,
+            exposure_mean_weight, color_mean_weight);
+    }
+
+    if (num_cameras > 0 &&
+        (vig_center_weight > 0.0f || vig_channel_weight > 0.0f || vig_non_pos_weight > 0.0f)) {
+        int total_vig = num_cameras * PPISP_VIGNETTING_PARAMS_PER_CHANNEL;
+        int blocks = divUp(total_vig, threads);
+        ppisp_regularization_vignetting_backward_kernel<<<blocks, threads>>>(
+            vignetting_params, grad_loss, grad_vignetting_params, num_cameras, vig_center_weight,
+            vig_channel_weight, vig_non_pos_weight);
+    }
+
+    if (num_cameras > 0 && crf_channel_weight > 0.0f) {
+        int total_crf = num_cameras * PPISP_CRF_PARAMS_PER_CHANNEL;
+        int blocks = divUp(total_crf, threads);
+        ppisp_regularization_crf_backward_kernel<<<blocks, threads>>>(
+            crf_params, grad_loss, grad_crf_params, num_cameras, crf_channel_weight);
+    }
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        printf("CUDA Error in ppisp_regularization_backward: %s\n", cudaGetErrorString(err));
     }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,9 @@ This directory contains tests for the PPISP CUDA implementation.
   - Uses `torch.autograd.gradcheck` for independent gradient validation
   - Gradient magnitude sanity checks
 
+- **test_regularization_loss.py**: Regularization loss tests
+  - Compares CUDA regularization loss and gradients against the PyTorch formula
+
 - **torch_reference.py**: PyTorch reference implementation (not tests)
   - Pure PyTorch implementation of PPISP pipeline
   - Used as ground truth for correctness testing
@@ -50,4 +53,5 @@ pytest tests/test_cuda_vs_torch.py::test_forward_basic -v
 - Different batch sizes (1 to 4096 pixels)
 - Multiple cameras and frames configurations
 - Disabled effects (camera_idx=-1, frame_idx=-1)
+- CUDA regularization loss and gradient correctness
 - Gradient magnitude sanity checks

--- a/tests/test_regularization_loss.py
+++ b/tests/test_regularization_loss.py
@@ -87,7 +87,6 @@ def _regularization_loss_torch(module: ppisp.PPISP) -> torch.Tensor:
 def _make_config(**overrides) -> ppisp.PPISPConfig:
     cfg = ppisp.PPISPConfig(
         use_controller=False,
-        use_cuda_regularization_loss=True,
         exposure_mean=0.7,
         vig_center=0.03,
         vig_channel=0.2,
@@ -185,33 +184,16 @@ def _assert_loss_and_grads_match(
         )
 
 
-def test_regularization_loss_constructor_cuda_override():
-    cfg = _make_config(use_cuda_regularization_loss=False)
-    module_config = ppisp.PPISP(
-        num_cameras=4,
-        num_frames=9,
-        config=_make_config(use_cuda_regularization_loss=True),
-    )
-    module_cuda = ppisp.PPISP(
-        num_cameras=4,
-        num_frames=9,
-        config=cfg,
-        use_cuda_regularization_loss=True,
-    )
+def test_regularization_loss_from_state_dict_matches_torch_reference():
+    cfg = _make_config()
+    module_cuda = ppisp.PPISP(num_cameras=4, num_frames=9, config=cfg)
     module_torch = ppisp.PPISP(num_cameras=4, num_frames=9, config=cfg)
-    assert module_config.use_cuda_regularization_loss is True
-    assert module_cuda.use_cuda_regularization_loss is True
-    assert module_torch.use_cuda_regularization_loss is False
+    _clone_params(_make_module(seed=5, config=cfg), module_cuda)
 
-    restored = ppisp.PPISP.from_state_dict(
-        module_cuda.state_dict(),
-        config=cfg,
-        use_cuda_regularization_loss=True,
-    )
-    assert restored.use_cuda_regularization_loss is True
+    restored = ppisp.PPISP.from_state_dict(module_cuda.state_dict(), config=cfg)
 
     _clone_params(module_cuda, module_torch)
-    _assert_loss_and_grads_match(module_cuda, module_torch)
+    _assert_loss_and_grads_match(restored, module_torch)
 
 
 def test_regularization_loss_matches_torch_reference():
@@ -368,7 +350,6 @@ def test_regularization_loss_mixed_weights_match_torch_reference(
 def test_regularization_loss_zero_weights_has_zero_grads():
     cfg = ppisp.PPISPConfig(
         use_controller=False,
-        use_cuda_regularization_loss=True,
         exposure_mean=0.0,
         vig_center=0.0,
         vig_channel=0.0,

--- a/tests/test_regularization_loss.py
+++ b/tests/test_regularization_loss.py
@@ -1,0 +1,682 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the CUDA implementation of PPISP regularization loss."""
+
+from dataclasses import replace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import ppisp
+import ppisp_cuda
+
+
+def _regularization_loss_torch_from_tensors(
+    exposure_params: torch.Tensor,
+    vignetting_params: torch.Tensor,
+    color_params: torch.Tensor,
+    crf_params: torch.Tensor,
+    color_pinv_block_diag: torch.Tensor,
+    cfg: ppisp.PPISPConfig,
+) -> torch.Tensor:
+    total_loss = torch.tensor(0.0, device=exposure_params.device)
+
+    if cfg.exposure_mean > 0:
+        exposure_residual = exposure_params.mean()
+        total_loss = total_loss + cfg.exposure_mean * F.smooth_l1_loss(
+            exposure_residual, torch.zeros_like(exposure_residual), beta=0.1
+        )
+
+    if cfg.vig_center > 0:
+        vig_optical_center = vignetting_params[:, :, :2]
+        vig_center = (vig_optical_center ** 2).sum(dim=-1)
+        total_loss = total_loss + cfg.vig_center * vig_center.mean()
+
+    if cfg.vig_non_pos > 0:
+        vig_alphas = vignetting_params[:, :, 2:]
+        total_loss = total_loss + cfg.vig_non_pos * F.relu(vig_alphas).mean()
+
+    if cfg.vig_channel > 0:
+        total_loss = total_loss + cfg.vig_channel * vignetting_params.var(
+            dim=1, unbiased=False
+        ).mean()
+
+    if cfg.color_mean > 0:
+        color_offsets = color_params @ color_pinv_block_diag
+        color_residual = color_offsets.mean(dim=0)
+        total_loss = total_loss + cfg.color_mean * F.smooth_l1_loss(
+            color_residual,
+            torch.zeros_like(color_residual),
+            beta=0.005,
+            reduction="mean",
+        )
+
+    if cfg.crf_channel > 0:
+        total_loss = total_loss + cfg.crf_channel * crf_params.var(
+            dim=1, unbiased=False
+        ).mean()
+
+    return total_loss
+
+
+def _regularization_loss_torch(module: ppisp.PPISP) -> torch.Tensor:
+    return _regularization_loss_torch_from_tensors(
+        module.exposure_params,
+        module.vignetting_params,
+        module.color_params,
+        module.crf_params,
+        module.color_pinv_block_diag,
+        module.config,
+    )
+
+
+def _make_config(**overrides) -> ppisp.PPISPConfig:
+    cfg = ppisp.PPISPConfig(
+        use_controller=False,
+        use_cuda_regularization_loss=True,
+        exposure_mean=0.7,
+        vig_center=0.03,
+        vig_channel=0.2,
+        vig_non_pos=0.05,
+        color_mean=1.3,
+        crf_channel=0.17,
+    )
+    return replace(cfg, **overrides)
+
+
+def _make_module(
+    seed: int = 0,
+    num_cameras: int = 4,
+    num_frames: int = 9,
+    config: ppisp.PPISPConfig | None = None,
+) -> ppisp.PPISP:
+    cfg = config or _make_config()
+    module = ppisp.PPISP(num_cameras=num_cameras, num_frames=num_frames, config=cfg)
+
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    with torch.no_grad():
+        module.exposure_params.copy_(
+            torch.randn(num_frames, device="cuda", generator=generator) * 0.2
+        )
+        module.vignetting_params.copy_(
+            torch.randn(
+                num_cameras, 3, ppisp.VIGNETTING_PARAMS_PER_CHANNEL,
+                device="cuda", generator=generator,
+            ) * 0.1
+        )
+        module.color_params.copy_(
+            torch.randn(
+                num_frames, ppisp.COLOR_PARAMS_PER_FRAME,
+                device="cuda", generator=generator,
+            ) * 0.2
+        )
+        module.crf_params.copy_(
+            torch.randn(
+                num_cameras, 3, ppisp.CRF_PARAMS_PER_CHANNEL,
+                device="cuda", generator=generator,
+            ) * 0.15
+        )
+    return module
+
+
+def _weights(cfg: ppisp.PPISPConfig) -> tuple[float, float, float, float, float, float]:
+    return (
+        cfg.exposure_mean,
+        cfg.vig_center,
+        cfg.vig_channel,
+        cfg.vig_non_pos,
+        cfg.color_mean,
+        cfg.crf_channel,
+    )
+
+
+def _clone_params(src: ppisp.PPISP, dst: ppisp.PPISP) -> None:
+    with torch.no_grad():
+        dst.exposure_params.copy_(src.exposure_params)
+        dst.vignetting_params.copy_(src.vignetting_params)
+        dst.color_params.copy_(src.color_params)
+        dst.crf_params.copy_(src.crf_params)
+
+
+def _assert_loss_and_grads_match(
+    module_cuda: ppisp.PPISP,
+    module_torch: ppisp.PPISP,
+    loss_atol: float = 1e-6,
+    grad_atol: float = 5e-6,
+    grad_rtol: float = 5e-5,
+) -> None:
+    loss_cuda = module_cuda.get_regularization_loss()
+    loss_torch = _regularization_loss_torch(module_torch)
+
+    assert torch.allclose(loss_cuda, loss_torch, atol=loss_atol), (
+        f"loss_cuda={loss_cuda.item()}, loss_torch={loss_torch.item()}"
+    )
+
+    loss_cuda.backward()
+    loss_torch.backward()
+
+    for name in ("exposure_params", "vignetting_params", "color_params", "crf_params"):
+        param_cuda = getattr(module_cuda, name)
+        param_torch = getattr(module_torch, name)
+        grad_cuda = param_cuda.grad
+        grad_torch = param_torch.grad
+        if grad_cuda is None:
+            grad_cuda = torch.zeros_like(param_cuda)
+        if grad_torch is None:
+            grad_torch = torch.zeros_like(param_torch)
+        max_diff = (grad_cuda - grad_torch).abs().max().item()
+        assert torch.allclose(grad_cuda, grad_torch, atol=grad_atol, rtol=grad_rtol), (
+            f"{name} grad max_diff={max_diff}"
+        )
+
+
+def test_regularization_loss_constructor_cuda_override():
+    cfg = _make_config(use_cuda_regularization_loss=False)
+    module_config = ppisp.PPISP(
+        num_cameras=4,
+        num_frames=9,
+        config=_make_config(use_cuda_regularization_loss=True),
+    )
+    module_cuda = ppisp.PPISP(
+        num_cameras=4,
+        num_frames=9,
+        config=cfg,
+        use_cuda_regularization_loss=True,
+    )
+    module_torch = ppisp.PPISP(num_cameras=4, num_frames=9, config=cfg)
+    assert module_config.use_cuda_regularization_loss is True
+    assert module_cuda.use_cuda_regularization_loss is True
+    assert module_torch.use_cuda_regularization_loss is False
+
+    restored = ppisp.PPISP.from_state_dict(
+        module_cuda.state_dict(),
+        config=cfg,
+        use_cuda_regularization_loss=True,
+    )
+    assert restored.use_cuda_regularization_loss is True
+
+    _clone_params(module_cuda, module_torch)
+    _assert_loss_and_grads_match(module_cuda, module_torch)
+
+
+def test_regularization_loss_matches_torch_reference():
+    module = _make_module(seed=12)
+
+    loss_cuda = module.get_regularization_loss()
+    loss_torch = _regularization_loss_torch(module)
+
+    assert torch.allclose(loss_cuda, loss_torch, atol=1e-6), (
+        f"loss_cuda={loss_cuda.item()}, loss_torch={loss_torch.item()}"
+    )
+
+
+def test_regularization_loss_backward_matches_torch_reference():
+    module_cuda = _make_module(seed=34)
+    module_torch = _make_module(seed=35)
+    _clone_params(module_cuda, module_torch)
+
+    _assert_loss_and_grads_match(module_cuda, module_torch)
+
+
+def test_regularization_loss_minimum_valid_shape_matches_torch_reference():
+    module_cuda = _make_module(seed=45, num_cameras=1, num_frames=1)
+    module_torch = _make_module(seed=46, num_cameras=1, num_frames=1)
+    _clone_params(module_cuda, module_torch)
+
+    _assert_loss_and_grads_match(module_cuda, module_torch)
+
+
+@pytest.mark.parametrize(
+    ("num_cameras", "num_frames", "seed"),
+    (
+        (1, 7, 101),
+        (2, 1, 102),
+        (5, 3, 103),
+        (7, 17, 104),
+        (13, 2, 105),
+        (2, 129, 106),
+    ),
+)
+def test_regularization_loss_shape_grid_matches_torch_reference(
+    num_cameras: int,
+    num_frames: int,
+    seed: int,
+):
+    module_cuda = _make_module(
+        seed=seed, num_cameras=num_cameras, num_frames=num_frames
+    )
+    module_torch = _make_module(
+        seed=seed + 1000, num_cameras=num_cameras, num_frames=num_frames
+    )
+    _clone_params(module_cuda, module_torch)
+
+    _assert_loss_and_grads_match(module_cuda, module_torch)
+
+
+@pytest.mark.parametrize(
+    "active_weight",
+    ("exposure_mean", "vig_center", "vig_channel", "vig_non_pos", "color_mean", "crf_channel"),
+)
+def test_regularization_loss_each_term_matches_torch_reference(active_weight: str):
+    weights = {
+        "exposure_mean": 0.0,
+        "vig_center": 0.0,
+        "vig_channel": 0.0,
+        "vig_non_pos": 0.0,
+        "color_mean": 0.0,
+        "crf_channel": 0.0,
+    }
+    weights[active_weight] = 1.0
+    cfg = _make_config(**weights)
+
+    module_cuda = _make_module(seed=active_weight.__hash__() % 1000, config=cfg)
+    module_torch = _make_module(seed=999, config=cfg)
+    _clone_params(module_cuda, module_torch)
+
+    _assert_loss_and_grads_match(module_cuda, module_torch)
+
+
+@pytest.mark.parametrize(
+    ("weights", "seed"),
+    (
+        (
+            {
+                "exposure_mean": 0.0,
+                "vig_center": 0.03,
+                "vig_channel": 0.0,
+                "vig_non_pos": 0.05,
+                "color_mean": 0.0,
+                "crf_channel": 0.17,
+            },
+            201,
+        ),
+        (
+            {
+                "exposure_mean": 0.7,
+                "vig_center": 0.0,
+                "vig_channel": 0.2,
+                "vig_non_pos": 0.0,
+                "color_mean": 1.3,
+                "crf_channel": 0.0,
+            },
+            202,
+        ),
+        (
+            {
+                "exposure_mean": 2.5,
+                "vig_center": 0.11,
+                "vig_channel": 0.013,
+                "vig_non_pos": 0.7,
+                "color_mean": 0.05,
+                "crf_channel": 3.0,
+            },
+            203,
+        ),
+        pytest.param(
+            {
+                "exposure_mean": 1.0,
+                "vig_center": 0.02,
+                "vig_channel": 0.1,
+                "vig_non_pos": 0.01,
+                "color_mean": 1.0,
+                "crf_channel": 0.1,
+            },
+            204,
+            id="nre_ppisp_post_processing_defaults",
+        ),
+        pytest.param(
+            {
+                "exposure_mean": 0.001,
+                "vig_center": 0.02,
+                "vig_channel": 0.01,
+                "vig_non_pos": 0.01,
+                "color_mean": 0.01,
+                "crf_channel": 0.01,
+            },
+            205,
+            id="nre_gaussians_av_ppisp_lambdas",
+        ),
+    ),
+)
+def test_regularization_loss_mixed_weights_match_torch_reference(
+    weights: dict[str, float],
+    seed: int,
+):
+    cfg = _make_config(**weights)
+    module_cuda = _make_module(seed=seed, config=cfg)
+    module_torch = _make_module(seed=seed + 1000, config=cfg)
+    _clone_params(module_cuda, module_torch)
+
+    _assert_loss_and_grads_match(module_cuda, module_torch)
+
+
+def test_regularization_loss_zero_weights_has_zero_grads():
+    cfg = ppisp.PPISPConfig(
+        use_controller=False,
+        use_cuda_regularization_loss=True,
+        exposure_mean=0.0,
+        vig_center=0.0,
+        vig_channel=0.0,
+        vig_non_pos=0.0,
+        color_mean=0.0,
+        crf_channel=0.0,
+    )
+    module = ppisp.PPISP(num_cameras=2, num_frames=3, config=cfg)
+
+    loss = module.get_regularization_loss()
+    loss.backward()
+
+    assert loss.item() == 0.0
+    for name in ("exposure_params", "vignetting_params", "color_params", "crf_params"):
+        grad = getattr(module, name).grad
+        assert grad is not None
+        assert torch.count_nonzero(grad).item() == 0
+
+
+def test_regularization_direct_binding_forward_shape_and_value():
+    module = _make_module(seed=56)
+
+    loss_direct, stats = ppisp_cuda.ppisp_regularization_forward(
+        module.exposure_params,
+        module.vignetting_params,
+        module.color_params,
+        module.crf_params,
+        *_weights(module.config),
+    )
+    loss_module = module.get_regularization_loss()
+
+    assert loss_direct.shape == torch.Size([])
+    assert loss_direct.device == module.exposure_params.device
+    assert loss_direct.dtype == module.exposure_params.dtype
+    assert stats.shape == torch.Size([1 + ppisp.COLOR_PARAMS_PER_FRAME])
+    assert stats.device == module.exposure_params.device
+    assert stats.dtype == module.exposure_params.dtype
+    assert torch.allclose(loss_direct, loss_module, atol=1e-6)
+
+
+def test_regularization_direct_binding_backward_shapes_and_grad_scale():
+    module = _make_module(seed=67)
+    module_torch = _make_module(seed=68)
+    _clone_params(module, module_torch)
+
+    grad_scale = torch.tensor(3.25, device="cuda")
+    _, stats = ppisp_cuda.ppisp_regularization_forward(
+        module.exposure_params,
+        module.vignetting_params,
+        module.color_params,
+        module.crf_params,
+        *_weights(module.config),
+    )
+    direct_grads = ppisp_cuda.ppisp_regularization_backward(
+        module.exposure_params,
+        module.vignetting_params,
+        module.color_params,
+        module.crf_params,
+        grad_scale,
+        stats,
+        *_weights(module.config),
+    )
+
+    (grad_exposure, grad_vignetting, grad_color, grad_crf) = direct_grads
+    expected_shapes = (
+        module.exposure_params.shape,
+        module.vignetting_params.shape,
+        module.color_params.shape,
+        module.crf_params.shape,
+    )
+    for grad, shape in zip(direct_grads, expected_shapes):
+        assert grad.shape == shape
+        assert grad.device == module.exposure_params.device
+        assert grad.dtype == module.exposure_params.dtype
+
+    (_regularization_loss_torch(module_torch) * grad_scale).backward()
+    expected = (
+        module_torch.exposure_params.grad,
+        module_torch.vignetting_params.grad,
+        module_torch.color_params.grad,
+        module_torch.crf_params.grad,
+    )
+    for grad, ref in zip((grad_exposure, grad_vignetting, grad_color, grad_crf), expected):
+        assert torch.allclose(grad, ref, atol=5e-6, rtol=5e-5)
+
+
+def test_regularization_loss_boundary_values_match_torch_reference():
+    cfg = _make_config()
+    module_cuda = ppisp.PPISP(num_cameras=2, num_frames=4, config=cfg)
+    module_torch = ppisp.PPISP(num_cameras=2, num_frames=4, config=cfg)
+
+    with torch.no_grad():
+        # Exposure mean is exactly SmoothL1 beta; vignetting alphas cover
+        # negative, zero, and positive ReLU branches.
+        module_cuda.exposure_params.fill_(0.1)
+        module_cuda.vignetting_params.zero_()
+        module_cuda.vignetting_params[:, :, 0] = 0.25
+        module_cuda.vignetting_params[:, :, 1] = -0.25
+        module_cuda.vignetting_params[:, :, 2:] = torch.tensor(
+            [-0.2, 0.0, 0.3], device="cuda"
+        )
+
+        module_cuda.color_params.zero_()
+        module_cuda.color_params[:, 0] = 0.005 / module_cuda.color_pinv_block_diag[0, 0]
+
+        module_cuda.crf_params.zero_()
+        module_cuda.crf_params[:, 0, :] = torch.tensor(
+            [0.2, -0.1, 0.0, 0.3], device="cuda"
+        )
+        module_cuda.crf_params[:, 1, :] = torch.tensor(
+            [-0.2, 0.1, 0.0, -0.3], device="cuda"
+        )
+        module_cuda.crf_params[:, 2, :] = torch.tensor(
+            [0.0, 0.0, 0.0, 0.0], device="cuda"
+        )
+
+    _clone_params(module_cuda, module_torch)
+    _assert_loss_and_grads_match(module_cuda, module_torch)
+
+
+def test_regularization_loss_color_block_explicit_expected_value():
+    cfg = _make_config(
+        exposure_mean=0.0,
+        vig_center=0.0,
+        vig_channel=0.0,
+        vig_non_pos=0.0,
+        color_mean=1.0,
+        crf_channel=0.0,
+    )
+    module = ppisp.PPISP(num_cameras=1, num_frames=1, config=cfg)
+    with torch.no_grad():
+        module.color_params.zero_()
+        module.color_params[0, 7] = 1.0
+
+    loss = module.get_regularization_loss()
+    neutral_block = torch.tensor(
+        [0.0128369, -0.0034654, -0.0034654, 0.0128158],
+        device="cuda",
+        dtype=torch.float32,
+    )
+    expected = (
+        F.smooth_l1_loss(
+            neutral_block[1],
+            torch.zeros_like(neutral_block[1]),
+            beta=0.005,
+            reduction="sum",
+        )
+        + F.smooth_l1_loss(
+            neutral_block[3],
+            torch.zeros_like(neutral_block[3]),
+            beta=0.005,
+            reduction="sum",
+        )
+    ) / ppisp.COLOR_PARAMS_PER_FRAME
+
+    assert torch.allclose(loss, expected, atol=1e-7)
+
+
+def test_regularization_loss_channel_equal_variance_terms_are_zero():
+    cfg = _make_config(
+        exposure_mean=0.0,
+        vig_center=0.0,
+        vig_channel=1.0,
+        vig_non_pos=0.0,
+        color_mean=0.0,
+        crf_channel=1.0,
+    )
+    module = ppisp.PPISP(num_cameras=3, num_frames=2, config=cfg)
+
+    with torch.no_grad():
+        vig = torch.randn(3, 1, ppisp.VIGNETTING_PARAMS_PER_CHANNEL, device="cuda")
+        crf = torch.randn(3, 1, ppisp.CRF_PARAMS_PER_CHANNEL, device="cuda")
+        module.vignetting_params.copy_(vig.repeat(1, 3, 1))
+        module.crf_params.copy_(crf.repeat(1, 3, 1))
+
+    loss = module.get_regularization_loss()
+    loss.backward()
+
+    assert torch.allclose(loss, torch.zeros_like(loss), atol=1e-10)
+    assert torch.allclose(
+        module.vignetting_params.grad,
+        torch.zeros_like(module.vignetting_params.grad),
+        atol=1e-8,
+    )
+    assert torch.allclose(
+        module.crf_params.grad,
+        torch.zeros_like(module.crf_params.grad),
+        atol=1e-8,
+    )
+
+
+def test_regularization_loss_large_multiblock_reduction_matches_torch_reference():
+    module_cuda = _make_module(seed=123, num_cameras=19, num_frames=513)
+    module_torch = _make_module(seed=124, num_cameras=19, num_frames=513)
+    _clone_params(module_cuda, module_torch)
+
+    # The CUDA path uses cross-block atomicAdd reductions. The exact summation
+    # order is not guaranteed, so this intentionally uses looser tolerances
+    # than the small single-block-style cases above.
+    _assert_loss_and_grads_match(
+        module_cuda,
+        module_torch,
+        loss_atol=2e-5,
+        grad_atol=1e-5,
+        grad_rtol=1e-4,
+    )
+
+
+def test_regularization_autograd_accepts_non_contiguous_inputs():
+    cfg = _make_config()
+    num_cameras = 3
+    num_frames = 5
+
+    exposure_base = torch.randn(num_frames, 2, device="cuda", requires_grad=True)
+    vignetting_base = torch.randn(
+        num_cameras, 3, ppisp.VIGNETTING_PARAMS_PER_CHANNEL * 2,
+        device="cuda", requires_grad=True,
+    )
+    color_base = torch.randn(
+        num_frames, ppisp.COLOR_PARAMS_PER_FRAME * 2,
+        device="cuda", requires_grad=True,
+    )
+    crf_base = torch.randn(
+        num_cameras, 3, ppisp.CRF_PARAMS_PER_CHANNEL * 2,
+        device="cuda", requires_grad=True,
+    )
+
+    exposure = exposure_base[:, 0]
+    vignetting = vignetting_base[:, :, ::2]
+    color = color_base[:, ::2]
+    crf = crf_base[:, :, ::2]
+    assert not exposure.is_contiguous()
+    assert not vignetting.is_contiguous()
+    assert not color.is_contiguous()
+    assert not crf.is_contiguous()
+
+    color_pinv = ppisp._COLOR_PINV_BLOCK_DIAG.to(device="cuda")
+    loss_cuda = ppisp._PPISPRegularizationFunction.apply(
+        exposure,
+        vignetting,
+        color,
+        crf,
+        cfg.exposure_mean,
+        cfg.vig_center,
+        cfg.vig_channel,
+        cfg.vig_non_pos,
+        cfg.color_mean,
+        cfg.crf_channel,
+    )
+    loss_torch = _regularization_loss_torch_from_tensors(
+        exposure,
+        vignetting,
+        color,
+        crf,
+        color_pinv,
+        cfg,
+    )
+
+    assert torch.allclose(loss_cuda, loss_torch, atol=1e-6)
+
+    loss_cuda.backward()
+    for base in (exposure_base, vignetting_base, color_base, crf_base):
+        assert base.grad is not None
+        assert torch.isfinite(base.grad).all()
+
+
+def test_regularization_color_pinv_blocks_are_symmetric():
+    color_pinv = ppisp._COLOR_PINV_BLOCK_DIAG
+    for block in range(4):
+        start = block * 2
+        assert torch.allclose(
+            color_pinv[start, start + 1],
+            color_pinv[start + 1, start],
+            atol=0.0,
+            rtol=0.0,
+        )
+
+
+def _central_difference(module: ppisp.PPISP, name: str, index: tuple[int, ...]) -> float:
+    param = getattr(module, name)
+    eps = 1e-3
+    with torch.no_grad():
+        original = param[index].item()
+        param[index] = original + eps
+        loss_plus = module.get_regularization_loss().item()
+
+    with torch.no_grad():
+        param[index] = original - eps
+        loss_minus = module.get_regularization_loss().item()
+
+    with torch.no_grad():
+        param[index] = original
+
+    return (loss_plus - loss_minus) / (2.0 * eps)
+
+
+def test_regularization_loss_tiny_finite_difference_gradients():
+    module = _make_module(seed=234, num_cameras=1, num_frames=2)
+    loss = module.get_regularization_loss()
+    loss.backward()
+
+    checks = (
+        ("exposure_params", (0,)),
+        ("vignetting_params", (0, 1, 3)),
+        ("color_params", (1, 5)),
+        ("crf_params", (0, 2, 1)),
+    )
+    for name, index in checks:
+        finite_diff = _central_difference(module, name, index)
+        analytic = getattr(module, name).grad[index].item()
+        assert analytic == pytest.approx(finite_diff, abs=5e-3, rel=5e-2)


### PR DESCRIPTION
- Introduced a new custom autograd function for PPISP regularization loss in `__init__.py`.
- Updated the `PPISP` class to utilize the new regularization function for loss computation.
- Added CUDA kernel implementations for forward and backward passes of the regularization loss in `ppisp_impl.cu`.
- Defined necessary bindings in `ext.cpp` and updated header files to include new functions.
- Created a new test file `test_regularization_loss.py` to validate the correctness of the regularization loss against a PyTorch reference implementation.
- Updated README to include information about the new regularization loss tests.


Experiments on both **H100** and **RTX 6000 Pro** of our internal 3dgut-based training, which has 40000 training steps with 1 epoch

# H100
## Wall Time
Improve from **6385 seconds** to **5958 seconds**
## Loss Time Improvements

- 0 - 999 steps: 283.00us vs 6528.84us
- 10000 - 10999 steps: 255.34us vs 5596.33us
- 20000 - 20999 steps: 261.52us vs 6143.08us
- 30000 - 30999 steps: 290.52us vs 7410.24us

## Quality Comparison
- PSNR: 27.841677 (cuda) vs 27.799282 (torch)
- SSIM: 0.881647 (cuda) vs 0.881447 (torch)
- LPIPS: 0.191591 (cuda) vs 0.192679 (torch)

# RTX 6000 Pro
## Wall Time
Improve from **4158 seconds** to **3808 seconds**
## Loss Time Improvements

- 0 - 999 steps: 154.13us vs 4365.15us
- 10000 - 10999 steps: 139.25us vs 4672.14us
- 20000 - 20999 steps: 130.87us vs 5479.88 us
- 30000 - 30999 steps: 145.82 us vs 7298.04 us

## Quality Comparison
- PSNR: 27.804377 (cuda) vs 27.810232 (torch)
- SSIM: 0.881480 (cuda) vs 0.880953 (torch)
- LPIPS: 0.191799 (cuda) vs 0.192077 (torch)
